### PR TITLE
Merge master into the source branch before merging

### DIFF
--- a/close-branch/close_branch.sh
+++ b/close-branch/close_branch.sh
@@ -44,9 +44,18 @@ if [ "$MERGED" = "true" ]; then
             jq .branch.branch_id)
     fi
 
-    MERGE_PAYLOAD="{\"force_conflict_resolve_using\":\"target\", \"target_branch_id\": $TARGET_BRANCH_ID}"
-    print_green "Merging ${SOURCE_BRANCH} into ${TARGET_BRANCH}..."
+    if [ "$TARGET_BRANCH" = "master" ]; then
+        print_green "Merging ${TARGET_BRANCH} into ${SOURCE_BRANCH} to ensure no strings to missing..."
+        MERGE_PAYLOAD="{\"force_conflict_resolve_using\":\"source\", \"target_branch_id\": $SOURCE_BRANCH_ID}"
+        curl --request POST --fail \
+            --url https://api.lokalise.com/api2/projects/${LOKALISE_PROJECT}/branches/$TARGET_BRANCH_ID/merge \
+            --header 'content-type: application/json' \
+            --header "x-api-token: $LOKALISE_TOKEN" \
+            --data "$MERGE_PAYLOAD"
+    fi
 
+    print_green "Merging ${SOURCE_BRANCH} into ${TARGET_BRANCH}..."
+    MERGE_PAYLOAD="{\"force_conflict_resolve_using\":\"target\", \"target_branch_id\": $TARGET_BRANCH_ID}"
     curl --request POST --fail \
         --url https://api.lokalise.com/api2/projects/${LOKALISE_PROJECT}/branches/$SOURCE_BRANCH_ID/merge \
         --header 'content-type: application/json' \

--- a/common.sh
+++ b/common.sh
@@ -1,24 +1,6 @@
 #!/bin/bash
 set -e
 
-if [ -z "$LOKALISE_TOKEN" ]; then
-    if [ "$CI" = "true" ]; then
-        print_error_and_exit "LOKALISE_TOKEN was not set"
-    elif [ -f "$HOME/.lokalise" ]; then
-        LOKALISE_TOKEN=$(cat "$HOME/.lokalise")
-    else
-        print_error_and_exit "LOKALISE_TOKEN was not set. You can create a file at ~/.lokalise with your token in it to retrieve it automatically."
-    fi
-fi
-
-if [ -z "$LOKALISE_PROJECT" ]; then
-    if [ -f ".lokalise" ]; then
-        LOKALISE_PROJECT=$(cat .lokalise)
-    else
-        print_error_and_exit "LOKALISE_PROJECT was not set. You can create a .lokalise file in the repository to retrieve it automatically."
-    fi
-fi
-
 # Set Bash platform script is running on (mac/windows/linux).
 # BSD (Mac) and GNU (Linux & Git for Windows) core-utils implementations
 # have some differences for example in the available command line options.
@@ -88,3 +70,21 @@ sed_replace() {
         sed -i "$@"
     fi
 }
+
+if [ -z "$LOKALISE_TOKEN" ]; then
+    if [ "$CI" = "true" ]; then
+        print_error_and_exit "LOKALISE_TOKEN was not set"
+    elif [ -f "$HOME/.lokalise" ]; then
+        LOKALISE_TOKEN=$(cat "$HOME/.lokalise")
+    else
+        print_error_and_exit "LOKALISE_TOKEN was not set. You can create a file at ~/.lokalise with your token in it to retrieve it automatically."
+    fi
+fi
+
+if [ -z "$LOKALISE_PROJECT" ]; then
+    if [ -f ".lokalise" ]; then
+        LOKALISE_PROJECT=$(cat .lokalise)
+    else
+        print_error_and_exit "LOKALISE_PROJECT was not set. You can create a .lokalise file in the repository to retrieve it automatically."
+    fi
+fi


### PR DESCRIPTION
Lokalise has an "feature" where strings get removed when branches are merged:

**Reproduction steps:**
1. master has string "foo"
2. branch is created and “foo” is deleted (for example by uploading a new localization file using Lokalise CLI with --cleanup-mode)
3. branch gets merged into master

**Expected outcome:**
“foo” remains on master

**Actual outcome:**
"foo" is deleted along with all its translations

This is a workaround to avoid deleting localizations from master. We first merge master with `force_conflict_resolve_using: source` into the branch. This re-adds the missing keys. Then we merge the branch into master.