### PR TITLE
Add optional async download mode

### DIFF
--- a/update-translations/action.yml
+++ b/update-translations/action.yml
@@ -4,16 +4,25 @@ inputs:
   localization-directory:
     description: The path to the localization directory. This should have directories inside for each language.
     required: true
+  use-async:
+    description: Use async mode for file download. Recommended for large projects with many translations. Required for projects with >= 10,000 key-language pairs.
+    required: false
+    default: 'false'
 runs:
   using: "composite"
   steps:
   - uses: YousicianGit/LokaliseActions/install-cli@main
   - name: Update translatios
     run: |
+      ASYNC_FLAG=""
+      if [ "${{ inputs.use-async }}" = "true" ]; then
+        ASYNC_FLAG="--async"
+      fi
       ${{ github.action_path }}/update_translations.sh ${{ inputs.localization-directory }} \
       --branch ${{ github.head_ref || github.ref_name }} \
       --stage-changes \
-      --unreviewed
+      --unreviewed \
+      $ASYNC_FLAG
     shell: bash
   - name: Check for changes to commit
     id: check_changes

--- a/update-translations/update_translations.sh
+++ b/update-translations/update_translations.sh
@@ -19,7 +19,7 @@ OPTIONS: All options are optional
         Stage changes to translation files. Used by CI to commit changes.
 
     --async
-        Use async mode for file download. Recommended for large projects with many translations. Will be required for projects with >= 10,000 key-language pairs from June 1st, 2025."
+        Use async mode for file download. Required for projects with >= 10,000 key-language pairs."
 
 
 # Import common functions

--- a/update-translations/update_translations.sh
+++ b/update-translations/update_translations.sh
@@ -16,7 +16,10 @@ OPTIONS: All options are optional
         Include unreviewed translations. This should be only used for testing. If not provided, only reviewed translations will be included.
 
     --stage-changes
-        Stage changes to translation files. Used by CI to commit changes."
+        Stage changes to translation files. Used by CI to commit changes.
+
+    --async
+        Use async mode for file download. Recommended for large projects with many translations. Will be required for projects with >= 10,000 key-language pairs from June 1st, 2025."
 
 
 # Import common functions
@@ -32,6 +35,7 @@ init_options() {
     INCLUDE_UNREVIEWED=false
     STAGE_CHANGES=false
     PROJECT_PATH=""
+    USE_ASYNC=false
 
     while [ $# -gt 0 ]; do
         case "$1" in
@@ -49,6 +53,9 @@ init_options() {
             --stage-changes)
                 STAGE_CHANGES=true
                 ;;
+            --async)
+                USE_ASYNC=true
+                ;;
         esac
         shift
     done
@@ -61,7 +68,12 @@ download_lokalise() {
         local mode="last_reviewed_only"
     fi
 
-    local command="lokalise2 file download --format po --unzip-to '$LOCALIZATION_FOLDER' --directory-prefix '%LANG_ISO%' --token '$LOKALISE_TOKEN' --filter-data $mode --project-id $LOKALISE_PROJECT"
+    local async_flag=""
+    if [ "$USE_ASYNC" = true ]; then
+        async_flag="--async"
+    fi
+
+    local command="lokalise2 file download --format po --unzip-to '$LOCALIZATION_FOLDER' --directory-prefix '%LANG_ISO%' --token '$LOKALISE_TOKEN' --filter-data $mode $async_flag --project-id $LOKALISE_PROJECT"
 
     if [ -n "$BRANCH" ]; then
         command="$command:$BRANCH"


### PR DESCRIPTION
Related ticket: https://yousician.atlassian.net/browse/WEB-1343

## Motivation and context

Lokalise requires us to switch to async download mode for projects with more than 10,000 keys

## Describe your changes

Add option to use async download mode to retrieve translations from Lokalise

Set `use-async: "true"` in github workflow file to start using it:
```
    - name: Update translations
      uses: YousicianGit/LokaliseActions/update-translations@main
      with:
        localization-directory: "src/locales"
>       use-async: "true"  
```